### PR TITLE
Fixes for controllers, same product guid but different instances

### DIFF
--- a/XB-Config/Classes/Controller.cs
+++ b/XB-Config/Classes/Controller.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.DirectX.DirectInput;
+using Microsoft.DirectX.DirectInput;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -64,7 +64,8 @@ namespace XBMonitor.Classes
             
             foreach (Device Device in Devices)
             {
-                if (Device.DeviceInformation.ProductGuid == DeviceGuid[Index].ProductGuid)
+                if (Device.DeviceInformation.ProductGuid == DeviceGuid[Index].ProductGuid &&
+                    Device.DeviceInformation.InstanceGuid == DeviceGuid[index].InstanceGuid)
                 {
                     try
                     {


### PR DESCRIPTION
Ran into a use case where I had 2 GP-2040 CE Joystick controllers, but with different instance guids.

Patch here is to not only look at the product guid for the controller, but the instance guid as well. If there was 2 controllers that were of the product, XB-Config would only take the "last" controller (in my case the second controller) as player 1. 

Compiled and tested against my setup and verified both GP-2040 CE controllers could be configured correctly.

Thanks again!